### PR TITLE
Migrate goreleaser config from brews to homebrew_casks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,14 +33,18 @@ changelog:
       - "^test:"
       - "^chore:"
 
-brews:
+homebrew_casks:
   - repository:
       owner: cboone
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
     homepage: "https://github.com/cboone/snappy"
     description: "Automatically increase your Time Machine snapshot frequency (macOS only)"
-    license: MIT
-    test: |
-      assert_match version.to_s, shell_output("#{bin}/snappy --version")
+    binaries:
+      - snappy
+    url:
+      verified: "github.com/cboone/snappy"
+    hooks:
+      post:
+        install:
+          - 'xattr -dr com.apple.quarantine "#{staged_path}/snappy"'


### PR DESCRIPTION
## Summary

- Replace deprecated `brews` section with `homebrew_casks` to resolve GoReleaser v2.10+ deprecation warning
- Add `url.verified` field for Homebrew audit compliance
- Add post-install hook to remove macOS quarantine attributes for unsigned binaries
- Remove formula-only fields (`directory`, `license`, `test`) and add cask-appropriate `binaries` list
- Filed [cboone/homebrew-tap#8](https://github.com/cboone/homebrew-tap/issues/8) to track the tap-side migration (deleting old Formula files, adding `tap_migrations.json`)

## Test plan

- [ ] Cut a test release and verify GoReleaser publishes a cask to `Casks/` in the tap repo
- [ ] Verify `brew install cboone/tap/snappy` installs correctly from the new cask
- [ ] Confirm the deprecation warning no longer appears in GoReleaser output

## Closes

Closes #25
