### PR TITLE
Reduce GitHub Actions runner usage

### DIFF
--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -5,3 +5,4 @@ applyTo: "**/*.go"
 # Go Code Guidelines
 
 - **Hardcoded program name in output**: Snappy is a small, single-binary CLI tool. Hardcoding "snappy" in user-facing output (e.g., version strings) is intentional. Do not suggest deriving the program name dynamically from `cmd.Root().Name()` or similar. The added indirection is unnecessary for this project.
+- **Build constraints and `./...` on Linux**: Only `main.go` has `//go:build darwin`. With Go 1.21+, `go test ./...`, `go vet ./...`, and `golangci-lint run ./...` silently skip packages where all files are excluded by build constraints. Do not suggest adding `!darwin` stub files or narrowing the package list to exclude the root package. The `./...` pattern works correctly on Linux as-is.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,25 +4,27 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
+      - "*.md"
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - ".claude/**"
+      - ".github/**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/PULL_REQUEST_TEMPLATE/**"
-      - "CODE_OF_CONDUCT.md"
-      - "CONTRIBUTING.md"
-      - "SECURITY.md"
+      - "docs/**"
+      - "LICENSE"
   pull_request:
     branches: [main]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
+      - "*.md"
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - ".claude/**"
+      - ".github/**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/PULL_REQUEST_TEMPLATE/**"
-      - "CODE_OF_CONDUCT.md"
-      - "CONTRIBUTING.md"
-      - "SECURITY.md"
+      - "docs/**"
+      - "LICENSE"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/plans/done/2026-03-03-reduce-gh-runner-usage.md
+++ b/docs/plans/done/2026-03-03-reduce-gh-runner-usage.md
@@ -93,25 +93,27 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
+      - "*.md"
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - ".claude/**"
+      - ".github/**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/PULL_REQUEST_TEMPLATE/**"
-      - "CODE_OF_CONDUCT.md"
-      - "CONTRIBUTING.md"
-      - "SECURITY.md"
+      - "docs/**"
+      - "LICENSE"
   pull_request:
     branches: [main]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
+      - "*.md"
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - ".claude/**"
+      - ".github/**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/PULL_REQUEST_TEMPLATE/**"
-      - "CODE_OF_CONDUCT.md"
-      - "CONTRIBUTING.md"
-      - "SECURITY.md"
+      - "docs/**"
+      - "LICENSE"
 ```
 
 **Trade-off:** If any CI job is a _required_ status check in branch protection,
@@ -153,13 +155,13 @@ risk for infrequent releases. Not worth changing.
 
 ## Expected Impact
 
-| Job            | Before            | After      | Savings  |
-| -------------- | ----------------- | ---------- | -------- |
-| `test`         | macos (10x)       | Linux (1x) | ~90%     |
-| `lint`         | macos (10x)       | Linux (1x) | ~90%     |
-| `test-scrut`   | macos (10x)       | macos (10x)| 0%       |
-| Docs-only runs | Full CI           | Skipped    | 100%     |
-| Stale PR runs  | Run to completion | Cancelled  | Variable |
+| Job            | Before            | After       | Savings  |
+| -------------- | ----------------- | ----------- | -------- |
+| `test`         | macos (10x)       | Linux (1x)  | ~90%     |
+| `lint`         | macos (10x)       | Linux (1x)  | ~90%     |
+| `test-scrut`   | macos (10x)       | macos (10x) | 0%       |
+| Docs-only runs | Full CI           | Skipped     | 100%     |
+| Stale PR runs  | Run to completion | Cancelled   | Variable |
 
 Net result: **2 of 3 CI jobs move from 10x to 1x cost**, docs-only changes skip
 CI entirely, and stale runs are cancelled. Estimated ~60-70% reduction in


### PR DESCRIPTION
## Summary

- Move `test` and `lint` jobs from `macos-latest` to `ubuntu-latest` (10x cost reduction per job)
- Add `paths-ignore` to skip CI entirely for docs-only changes (Markdown, LICENSE, community files)
- Add workflow-level concurrency controls to cancel stale in-progress runs on rapid pushes
- Keep `test-scrut` on `macos-latest` since it requires darwin compilation and macOS-specific commands

## Test plan

- [ ] Push a branch with Go code changes and confirm `test` and `lint` run on `ubuntu-latest` while `test-scrut` runs on `macos-latest`
- [ ] Confirm all three jobs pass
- [ ] Push a docs-only commit and confirm CI does not trigger
- [ ] Push two commits quickly to a PR branch and confirm the first run is cancelled
- [ ] Run `make lint-actions` locally to validate workflow syntax (already passing)
