### PR TITLE
Add shift+tab to cycle panel focus in reverse

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -25,6 +25,7 @@ type keyMap struct {
 	ScrollUp   key.Binding
 	ScrollDown key.Binding
 	Tab        key.Binding
+	ShiftTab   key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
@@ -34,7 +35,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Snapshot, k.Refresh, k.AutoSnap, k.OpenLog, k.Quit},
-		{k.ScrollUp, k.ScrollDown, k.Tab},
+		{k.ScrollUp, k.ScrollDown, k.Tab, k.ShiftTab},
 	}
 }
 
@@ -70,7 +71,11 @@ func defaultKeyMap() keyMap {
 		),
 		Tab: key.NewBinding(
 			key.WithKeys("tab"),
-			key.WithHelp("tab", "focus"),
+			key.WithHelp("tab", "next panel"),
+		),
+		ShiftTab: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "prev panel"),
 		),
 	}
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -211,6 +211,10 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.setFocusPanel((m.focusPanel + 1) % 3)
 		return m, nil
 
+	case key.Matches(msg, m.keys.ShiftTab):
+		m.setFocusPanel((m.focusPanel + 2) % 3)
+		return m, nil
+
 	case key.Matches(msg, m.keys.ScrollUp, m.keys.ScrollDown):
 		return m.handleScroll(msg)
 	}


### PR DESCRIPTION
## Summary

- Add `shift+tab` key binding to cycle panel focus in reverse (Log -> Snap -> Info)
- Update existing `tab` help text from "focus" to "next panel" for clarity
- Add `shift+tab` to the full help bindings list with "prev panel" description

## Test plan

- [ ] Run the TUI and press `tab` to confirm forward focus cycling still works (Info -> Snap -> Log)
- [ ] Press `shift+tab` to confirm reverse focus cycling works (Log -> Snap -> Info)
- [ ] Verify the help bar shows both `tab` and `shift+tab` bindings in full help mode
