### PR TITLE
Rate-limit repeated tidemark WARN logs

### DIFF
--- a/docs/plans/done/2026-03-07-rate-limit-tidemark-warnings.md
+++ b/docs/plans/done/2026-03-07-rate-limit-tidemark-warnings.md
@@ -1,0 +1,85 @@
+# Rate-limit repeated tidemark WARN logs
+
+Issue: #86
+
+## Context
+
+`applyTidemark` in `internal/tui/update.go` logs a WARN on every refresh cycle
+(default 60 seconds) when tidemark retrieval fails. A persistent failure (e.g.,
+unsupported volume or container) fills the ring buffer with duplicate warnings,
+reducing visibility of other log messages.
+
+The codebase already uses a "log on change" pattern in several places:
+
+- `logRefreshSummary()` tracks `m.lastRefreshSummary` and only logs when the
+  summary string changes.
+- `applyAPFSInfo()` tracks `m.lastOtherSnapCount` and only logs when the count
+  changes.
+
+The fix applies the same pattern to tidemark errors.
+
+## Changes
+
+### 1. Add a `lastTidemarkErr` field to `Model`
+
+File: `internal/tui/model.go`
+
+Add a `lastTidemarkErr string` field to the `Model` struct, grouped with the
+other "last seen" state fields (`lastOtherSnapCount`, `lastRefreshSummary`).
+
+No initialization needed (zero value `""` is correct for "no previous error").
+
+### 2. Deduplicate tidemark warnings in `applyTidemark`
+
+File: `internal/tui/update.go`
+
+Update `applyTidemark` to only log when the error message differs from the
+previously seen error:
+
+```go
+func (m *Model) applyTidemark(msg RefreshResultMsg) {
+    errMsg := ""
+    if msg.TidemarkErr != nil {
+        errMsg = msg.TidemarkErr.Error()
+    }
+    if errMsg != "" && errMsg != m.lastTidemarkErr {
+        m.log.Log(logger.LevelWarn, logger.CatRefresh,
+            "Tidemark fetch failed: "+errMsg)
+    }
+    m.lastTidemarkErr = errMsg
+
+    if msg.Tidemark > 0 {
+        m.tidemark = platform.FormatBytes(msg.Tidemark)
+    } else {
+        m.tidemark = ""
+    }
+}
+```
+
+Behavior:
+
+- First failure: logged at WARN (errMsg differs from initial `""`)
+- Repeated identical failure: suppressed (errMsg == lastTidemarkErr)
+- Different failure reason: logged again (new errMsg)
+- Error clears then recurs: logged again (lastTidemarkErr was reset to `""`)
+
+### 3. Update the existing test
+
+File: `internal/tui/model_test.go`
+
+`TestTidemarkFetchFailureLogged` (line 2025) already verifies the first warning
+is logged. Extend it to confirm that a second refresh with the same error does
+NOT produce a duplicate warning entry.
+
+### 4. Add a test for changed error messages
+
+File: `internal/tui/model_test.go`
+
+Add a test that verifies: when the tidemark error message changes between
+refreshes, the new error IS logged.
+
+## Verification
+
+1. `make test` -- unit tests pass, including the updated/new tidemark tests
+2. `make lint` -- no lint issues introduced
+3. `make build` -- binary compiles cleanly

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -102,6 +102,7 @@ type Model struct {
 	apfsContainer      string
 	volumeName         string
 	lastOtherSnapCount int
+	lastTidemarkErr    string
 	diskInfo           string
 	tidemark           string
 	lastRefresh        time.Time

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2027,24 +2027,70 @@ func TestTidemarkFetchFailureLogged(t *testing.T) {
 	now := time.Date(2026, 3, 1, 15, 0, 0, 0, time.Local)
 	m.now = func() time.Time { return now }
 
-	updated, _ := m.Update(RefreshResultMsg{
+	refreshMsg := RefreshResultMsg{
 		Snapshots:   []snapshot.Snapshot{{Date: "2026-03-01-143000", Time: now.Add(-30 * time.Minute)}},
 		TMStatus:    "Configured",
 		DiskInfo:    platform.DiskInfo{Total: "460Gi", Used: "215Gi", Available: "242Gi", Percent: "48%"},
 		TidemarkErr: fmt.Errorf("container not found"),
-	})
+	}
+
+	updated, _ := m.Update(refreshMsg)
 	model := updated.(Model)
 
-	entries := model.log.Entries()
-	var found bool
-	for _, e := range entries {
+	countWarnings := func(entries []logger.Entry) int {
+		n := 0
+		for _, e := range entries {
+			if e.Level == logger.LevelWarn && strings.Contains(e.Message, "Tidemark fetch failed") {
+				n++
+			}
+		}
+		return n
+	}
+
+	if n := countWarnings(model.log.Entries()); n != 1 {
+		t.Errorf("expected 1 WARN log for tidemark fetch failure, got %d", n)
+	}
+
+	// A second refresh with the same error should NOT produce a duplicate warning.
+	updated2, _ := model.Update(refreshMsg)
+	model2 := updated2.(Model)
+
+	if n := countWarnings(model2.log.Entries()); n != 1 {
+		t.Errorf("expected 1 WARN log after duplicate tidemark error, got %d", n)
+	}
+}
+
+func TestTidemarkFetchFailureLoggedOnChange(t *testing.T) {
+	m := testModel()
+	now := time.Date(2026, 3, 1, 15, 0, 0, 0, time.Local)
+	m.now = func() time.Time { return now }
+
+	base := RefreshResultMsg{
+		Snapshots: []snapshot.Snapshot{{Date: "2026-03-01-143000", Time: now.Add(-30 * time.Minute)}},
+		TMStatus:  "Configured",
+		DiskInfo:  platform.DiskInfo{Total: "460Gi", Used: "215Gi", Available: "242Gi", Percent: "48%"},
+	}
+
+	// First error.
+	msg1 := base
+	msg1.TidemarkErr = fmt.Errorf("container not found")
+	updated, _ := m.Update(msg1)
+	model := updated.(Model)
+
+	// Different error should produce a second warning.
+	msg2 := base
+	msg2.TidemarkErr = fmt.Errorf("permission denied")
+	updated2, _ := model.Update(msg2)
+	model2 := updated2.(Model)
+
+	warnings := 0
+	for _, e := range model2.log.Entries() {
 		if e.Level == logger.LevelWarn && strings.Contains(e.Message, "Tidemark fetch failed") {
-			found = true
-			break
+			warnings++
 		}
 	}
-	if !found {
-		t.Error("expected WARN log for tidemark fetch failure")
+	if warnings != 2 {
+		t.Errorf("expected 2 WARN logs for different tidemark errors, got %d", warnings)
 	}
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -511,11 +511,19 @@ func (m *Model) applyAPFSInfo(msg RefreshResultMsg) {
 }
 
 // applyTidemark updates the tidemark display from a refresh result.
+// It only logs a warning when the error message changes from the previous
+// refresh, preventing duplicate warnings from filling the ring buffer.
 func (m *Model) applyTidemark(msg RefreshResultMsg) {
+	errMsg := ""
 	if msg.TidemarkErr != nil {
-		m.log.Log(logger.LevelWarn, logger.CatRefresh,
-			"Tidemark fetch failed: "+msg.TidemarkErr.Error())
+		errMsg = msg.TidemarkErr.Error()
 	}
+	if errMsg != "" && errMsg != m.lastTidemarkErr {
+		m.log.Log(logger.LevelWarn, logger.CatRefresh,
+			"Tidemark fetch failed: "+errMsg)
+	}
+	m.lastTidemarkErr = errMsg
+
 	if msg.Tidemark > 0 {
 		m.tidemark = platform.FormatBytes(msg.Tidemark)
 	} else {


### PR DESCRIPTION
## Summary

- Deduplicate tidemark fetch failure warnings by tracking the last error message in a new `lastTidemarkErr` field on the TUI model
- Only log a WARN when the error message changes from the previous refresh, matching the existing "log on change" pattern used by `logRefreshSummary` and `applyAPFSInfo`
- Extend tests to verify duplicate suppression and re-logging on error change

## Test plan

- [x] `make test` passes, including updated `TestTidemarkFetchFailureLogged` (duplicate suppression) and new `TestTidemarkFetchFailureLoggedOnChange` (different errors logged)
- [x] `make lint` passes with zero issues
- [x] `make build` compiles cleanly

## Closes

Fixes #86
