### PR TITLE
chore: pin gh-actions to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,20 +30,20 @@ concurrency:
 
 jobs:
   ci:
-    uses: cboone/gh-actions/.github/workflows/go-ci.yml@main
+    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v1
     with:
       run-lint: true
       run-build: true
       run-format-check: true
 
   text-lint:
-    uses: cboone/gh-actions/.github/workflows/text-lint.yml@main
+    uses: cboone/gh-actions/.github/workflows/text-lint.yml@v1
 
   shell-lint:
-    uses: cboone/gh-actions/.github/workflows/shell-lint.yml@main
+    uses: cboone/gh-actions/.github/workflows/shell-lint.yml@v1
 
   github-lint:
-    uses: cboone/gh-actions/.github/workflows/github-lint.yml@main
+    uses: cboone/gh-actions/.github/workflows/github-lint.yml@v1
 
   test-scrut:
     name: Test CLI (Scrut)
@@ -56,7 +56,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: cboone/gh-actions/actions/setup-scrut@main
+      - uses: cboone/gh-actions/actions/setup-scrut@v1
 
       - name: Run scrut CLI tests
         run: make test-scrut

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   release:
-    uses: cboone/gh-actions/.github/workflows/go-release.yml@main
+    uses: cboone/gh-actions/.github/workflows/go-release.yml@v1
     with:
       runs-on: macos-latest
     secrets:


### PR DESCRIPTION
## Summary

- Pin `cboone/gh-actions` references from `@main` to `@v1`

The gh-actions repo has been tagged with v1.0.0. Using the floating `@v1` tag ensures we automatically pick up non-breaking updates while maintaining stability.