### PR TITLE
Exclude .md from Prettier, rely on markdownlint-cli2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@ go.sum
 
 # Generated files
 coverage/
+
+# Markdown (formatted by markdownlint-cli2, not Prettier)
+*.md


### PR DESCRIPTION
## Summary

- Exclude `*.md` from Prettier since it normalizes ordered lists to `1.` with no config option to disable
- markdownlint-cli2 `--fix` already handles markdown formatting