### PR TITLE
chore: pin gh-actions to v2.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v2
+    uses: cboone/gh-actions/.github/workflows/go-ci.yml@v2.1.2
     with:
       runs-on: macos-latest
       run-lint: true
@@ -38,13 +38,13 @@ jobs:
       run-format-check: true
 
   text-lint:
-    uses: cboone/gh-actions/.github/workflows/text-lint.yml@v1
+    uses: cboone/gh-actions/.github/workflows/text-lint.yml@v2.1.2
 
   shell-lint:
-    uses: cboone/gh-actions/.github/workflows/shell-lint.yml@v1
+    uses: cboone/gh-actions/.github/workflows/shell-lint.yml@v2.1.2
 
   github-lint:
-    uses: cboone/gh-actions/.github/workflows/github-lint.yml@v1
+    uses: cboone/gh-actions/.github/workflows/github-lint.yml@v2.1.2
 
   test-scrut:
     name: Test CLI (Scrut)
@@ -57,7 +57,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: cboone/gh-actions/actions/setup-scrut@v1
+      - uses: cboone/gh-actions/actions/setup-scrut@v2.1.2
 
       - name: Run scrut CLI tests
         run: make test-scrut

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   release:
-    uses: cboone/gh-actions/.github/workflows/go-release.yml@v1
+    uses: cboone/gh-actions/.github/workflows/go-release.yml@v2.1.2
     with:
       runs-on: macos-latest
     secrets:


### PR DESCRIPTION
Pin all `cboone/gh-actions` workflow and action references from floating
tags (`@v1`, `@v2`) to the exact version `@v2.1.2`.

Part of the migration to exact-version-only tagging (cboone/gh-actions#25).
After all consuming repos are updated, the floating `v1` and `v2` tags
will be deleted from the gh-actions remote.